### PR TITLE
Change les liens dossiersco en span dans l'entête

### DIFF
--- a/views/layout.erb
+++ b/views/layout.erb
@@ -18,7 +18,7 @@
 <body>
 
   <nav class="navbar navbar-light navbar-expand-md fixed-top" style="background-color: transparent;">
-    <a class="navbar-brand" href="/r0"><strong style="color: #2d9ee0;">dossiersco web</strong></a>
+    <a class="navbar-brand" href="/"><strong style="color: #2d9ee0;">dossiersco web</strong></a>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>

--- a/views/layout.erb
+++ b/views/layout.erb
@@ -18,7 +18,7 @@
 <body>
 
   <nav class="navbar navbar-light navbar-expand-md fixed-top" style="background-color: transparent;">
-    <a class="navbar-brand" href="/"><strong style="color: #2d9ee0;">dossiersco web</strong></a>
+    <span class="navbar-brand"><strong style="color: #2d9ee0;">dossiersco web</strong></span>
     <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
       <span class="navbar-toggler-icon"></span>
     </button>

--- a/views/layout_agent.erb
+++ b/views/layout_agent.erb
@@ -17,7 +17,7 @@
   <body>
 
     <nav class="navbar navbar-light navbar-expand-md fixed-top justify-content-between" style="background-color: transparent;">
-      <a class="navbar-brand" href="/"><strong style="color: #2d9ee0;">dossiersco web</strong></a>
+      <span class="navbar-brand"><strong style="color: #2d9ee0;">dossiersco web</strong></span>
       <ul class="nav">
         <li class="nav-item">
           <a class="nav-link disabled" href="#">Collège Jean Lurçat</a>

--- a/views/layout_agent.erb
+++ b/views/layout_agent.erb
@@ -17,7 +17,7 @@
   <body>
 
     <nav class="navbar navbar-light navbar-expand-md fixed-top justify-content-between" style="background-color: transparent;">
-      <a class="navbar-brand" href="#"><strong style="color: #2d9ee0;">dossiersco web</strong></a>
+      <a class="navbar-brand" href="/"><strong style="color: #2d9ee0;">dossiersco web</strong></a>
       <ul class="nav">
         <li class="nav-item">
           <a class="nav-link disabled" href="#">Collège Jean Lurçat</a>

--- a/views/partials/nav.erb
+++ b/views/partials/nav.erb
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-light navbar-expand-md fixed-top" style="background-color: transparent;">
 
-  <a class="navbar-brand" href="/"><strong style="color: #2d9ee0;">dossiersco web</strong></a>
+  <span class="navbar-brand"><strong style="color: #2d9ee0;">dossiersco web</strong></span>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>

--- a/views/partials/nav.erb
+++ b/views/partials/nav.erb
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-light navbar-expand-md fixed-top" style="background-color: transparent;">
 
-  <a class="navbar-brand" href="accueil"><strong style="color: #2d9ee0;">dossiersco web</strong></a>
+  <a class="navbar-brand" href="/"><strong style="color: #2d9ee0;">dossiersco web</strong></a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>

--- a/views/partials/nav_light.erb
+++ b/views/partials/nav_light.erb
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-light navbar-expand-md fixed-top" style="background-color: transparent;">
 
-  <a class="navbar-brand" href="/"><strong style="color: #2d9ee0;">dossiersco web</strong></a>
+  <span class="navbar-brand"><strong style="color: #2d9ee0;">dossiersco web</strong></span>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>

--- a/views/partials/nav_light.erb
+++ b/views/partials/nav_light.erb
@@ -1,6 +1,6 @@
 <nav class="navbar navbar-light navbar-expand-md fixed-top" style="background-color: transparent;">
 
-  <a class="navbar-brand" href="accueil"><strong style="color: #2d9ee0;">dossiersco web</strong></a>
+  <a class="navbar-brand" href="/"><strong style="color: #2d9ee0;">dossiersco web</strong></a>
   <button class="navbar-toggler" type="button" data-toggle="collapse" data-target="#navbarsExampleDefault" aria-controls="navbarsExampleDefault" aria-expanded="false" aria-label="Toggle navigation">
     <span class="navbar-toggler-icon"></span>
   </button>


### PR DESCRIPTION
Corrige les erreurs de type "NameError at /accueil" (ou /r0...) quand je clique sur le lien à différentes étapes du processus d'inscription.