### PR TITLE
[UX] Change Régime en Cantine

### DIFF
--- a/views/4_administration.erb
+++ b/views/4_administration.erb
@@ -12,25 +12,25 @@
 
 			<span style="display:block; height: 80px;"></span>
 
-			<a data-toggle="collapse" data-parent="#accordeon-admin" href="#accordeon-admin-regime" aria-expanded="false" aria-controls="accordeon-admin-regime">
+			<a data-toggle="collapse" data-parent="#accordeon-admin" href="#accordeon-admin-cantine" aria-expanded="false" aria-controls="accordeon-admin-cantine">
 
 				<div class="row posit-relat">
-					<div class="col"><h2 class="not-first">Régime</h2></div>
+					<div class="col"><h2 class="not-first">Cantine</h2></div>
 					<div class="col posit-absol"><img src="images/chevron_bas.png" alt="déplier" title="déplier"></div>
 				</div>
 				<hr>
 			</a>
-			<div id="accordeon-admin-regime" class="collapse" role="tabpanel">
+			<div id="accordeon-admin-cantine" class="collapse" role="tabpanel">
 				<form>
 
 					<div class="form-group row">
-						<label for="regime" class="col-sm-3 col-form-label">Choix du régime</label>
+						<label for="cantine" class="col-sm-3 col-form-label">Choix de la cantine</label>
 						<div class="col-sm-6">
 							<label class="col-sm-7 form-check-label">
-								<input type="radio" name="regime" class="form-check-input trigger" onclick="afficher_dp(event)"> Demi-pensionnaire
+								<input type="radio" name="cantine" class="form-check-input trigger" onclick="afficher_dp(event)"> Demi-pensionnaire
 							</label>
 							<label class="col-sm-4 form-check-label">
-								<input type="radio" name="regime" class="form-check-input trigger" onclick="masquer_dp(event)"> Externe
+								<input type="radio" name="cantine" class="form-check-input trigger" onclick="masquer_dp(event)"> Externe
 							</label>
 						</div>
 					</div>

--- a/views/6_validation.erb
+++ b/views/6_validation.erb
@@ -58,7 +58,7 @@
 
 			<div class="row">
 				<div class="col-3">
-					<strong>Régime</strong>
+					<strong>Cantine</strong>
 				</div>
 				<div class="col-4">
 					Demi-pensionnaire

--- a/views/partials/progression_secondaire.erb
+++ b/views/partials/progression_secondaire.erb
@@ -7,8 +7,8 @@
 
   <% else %>
 
-    <% sous_sections = {1 => "4.1. Régime", 2 => "4.2. Autorisation de sortie", 3 => "4.3. Renseignements médicaux", 4 => "4.4. Droit à l'image"} %>
-    <% sous_sections_liens = {1 => "regime", 2 => "autorisation_sortie", 3 => "medical", 4 => "droit_image"} %>
+    <% sous_sections = {1 => "4.1. Cantine", 2 => "4.2. Autorisation de sortie", 3 => "4.3. Renseignements médicaux", 4 => "4.4. Droit à l'image"} %>
+    <% sous_sections_liens = {1 => "cantine", 2 => "autorisation_sortie", 3 => "medical", 4 => "droit_image"} %>
 
   <% end %>
 

--- a/views/r2_famille.erb
+++ b/views/r2_famille.erb
@@ -5,7 +5,7 @@
 
       <span style="display:block; height: 80px;"></span>
 
-      <a data-toggle="collapse" data-parent="#accordeon-admin" href="#accordeon-admin-regime" aria-expanded="false" aria-controls="accordeon-admin-regime">
+      <a data-toggle="collapse" data-parent="#accordeon-admin" href="#accordeon-admin-cantine" aria-expanded="false" aria-controls="accordeon-admin-cantine">
 
         <div class="row posit-relat">
           <div class="col"><h2 class="not-first">Représentant légal 1</h2></div>
@@ -13,7 +13,7 @@
         </div>
         <hr>
       </a>
-      <div id="accordeon-admin-regime" class="collapse" role="tabpanel">
+      <div id="accordeon-admin-cantine" class="collapse" role="tabpanel">
         <form>
 
 	        <div class="row">


### PR DESCRIPTION
Le terme *Régime* a montré lors d'interview utilisateurs qu'il était source de plusieurs confusions possibles :
- avec le régime alimentaire (végétarien, alergies)
- avec le régime de l'Assurance Maladie

Lors d'une discussion avec @rosedeschamps a donc émergée l'idée de le renommer en **restauration** ou **cantine**. Je propose **cantine** car il est plus court et me semble plus restreint au contexte d'un établissement scolaire que **restauration** (qui évoquerait également les hôtels et les restaurants).