### PR TITLE
Affichage des options

### DIFF
--- a/dossiersco_web.rb
+++ b/dossiersco_web.rb
@@ -105,20 +105,20 @@ end
 post '/eleve' do
   eleve = get_eleve session[:identifiant]
   identite_eleve = ['prenom', 'prenom_2', 'prenom_3', 'nom', 'sexe', 'ville_naiss', 'pays_naiss', 'nationalite', 'classe_ant', 'ets_ant']
-  options = options_du_niveau eleve, eleve.dossier_eleve.etablissement.id
-  nom_options = options.map { |option| option.nom }
   identite_eleve.each do |info|
 	 eleve[info] = params[info] if params.has_key?(info)
   end
 
-  nom_options.each do |nom_option|
-    if params.has_key?(nom_option) or params.has_value?(nom_option)
-      option_choisit = Option.find_by(nom: nom_option, etablissement_id: eleve.dossier_eleve.etablissement.id)
-      eleve.option << option_choisit unless eleve.option.include? option_choisit
-    else
-      eleve.option.delete eleve.option.select { |o| o.nom == nom_option }
-    end
-  end
+  # options = options_du_niveau eleve, eleve.dossier_eleve.etablissement.id
+  # nom_options = options.map { |option| option.nom }
+  # nom_options.each do |nom_option|
+  #   if params.has_key?(nom_option) or params.has_value?(nom_option)
+  #     option_choisit = Option.find_by(nom: nom_option, etablissement_id: eleve.dossier_eleve.etablissement.id)
+  #     eleve.option << option_choisit unless eleve.option.include? option_choisit
+  #   else
+  #     eleve.option.delete eleve.option.select { |o| o.nom == nom_option }
+  #   end
+  # end
   eleve.save!
 
   sauve_et_redirect eleve.dossier_eleve, 'famille'

--- a/tests/test_eleve_form.rb
+++ b/tests/test_eleve_form.rb
@@ -90,16 +90,16 @@ class EleveFormTest < Test::Unit::TestCase
     assert last_response.body.include? 'Piaf'
   end
 
-  def test_persistence_des_choix_enseignements
-    post '/identification', identifiant: '2', date_naiss: '1915-12-19'
-    post '/eleve', Espagnol: true, Latin: true
-    get '/eleve'
+  # def test_persistence_des_choix_enseignements
+  #   post '/identification', identifiant: '2', date_naiss: '1915-12-19'
+  #   post '/eleve', Espagnol: true, Latin: true
+  #   get '/eleve'
 
-    assert last_response.body.gsub(/\s/,'').include?(
-     '<input name="Langue vivante 2" value="Espagnol" type="radio" class="form-check-input" checked>'.gsub(/\s/,''))
-    assert last_response.body.gsub(/\s/,'').include?(
-     "<input class='form-check-input' type='checkbox' name='Latin' value='true' id='Latin' checked >".gsub(/\s/,''))
-  end
+  #   assert last_response.body.gsub(/\s/,'').include?(
+  #    '<input name="Langue vivante 2" value="Espagnol" type="radio" class="form-check-input" checked>'.gsub(/\s/,''))
+  #   assert last_response.body.gsub(/\s/,'').include?(
+  #    "<input class='form-check-input' type='checkbox' name='Latin' value='true' id='Latin' checked >".gsub(/\s/,''))
+  # end
 
   def test_affiche_2ème_et_3ème_prénoms_en_4ème_pour_brevet_des_collèges
     post '/identification', identifiant: '4', date_naiss: '1970-01-01'
@@ -504,16 +504,16 @@ class EleveFormTest < Test::Unit::TestCase
     assert last_response.body.gsub(/\s/,'').include? "id='autorise_photo_de_classe' checked".gsub(/\s/,'')
   end
 
-  def test_un_agent_ajoute_une_nouvelle_option_obligatoire
-    post '/agent', identifiant: 'pierre', mot_de_passe: 'demaulmont'
+  # def test_un_agent_ajoute_une_nouvelle_option_obligatoire
+  #   post '/agent', identifiant: 'pierre', mot_de_passe: 'demaulmont'
 
-    post '/agent/options', nom: 'Italien', niveau_debut: '4ème', obligatoire: true
+  #   post '/agent/options', nom: 'Italien', niveau_debut: '4ème', obligatoire: true
 
-    post '/identification', identifiant: '5', date_naiss: '1970-01-01'
-    get '/eleve'
-    assert_match /Italien/, last_response.body
-    assert_match /obligatoire/, last_response.body
-  end
+  #   post '/identification', identifiant: '5', date_naiss: '1970-01-01'
+  #   get '/eleve'
+  #   assert_match /Italien/, last_response.body
+  #   assert_match /obligatoire/, last_response.body
+  # end
 
   def test_un_agent_ajoute_deux_fois_la_meme_option
     post '/agent', identifiant: 'pierre', mot_de_passe: 'demaulmont'
@@ -524,16 +524,16 @@ class EleveFormTest < Test::Unit::TestCase
     assert_match /latin existe déjà/, last_response.body
   end
 
-  def test_un_agent_ajoute_une_nouvelle_option_facultative
-    post '/agent', identifiant: 'pierre', mot_de_passe: 'demaulmont'
+  # def test_un_agent_ajoute_une_nouvelle_option_facultative
+  #   post '/agent', identifiant: 'pierre', mot_de_passe: 'demaulmont'
 
-    post '/agent/options', nom: 'Musique', niveau_debut: '3ème', obligatoire: false
+  #   post '/agent/options', nom: 'Musique', niveau_debut: '3ème', obligatoire: false
 
-    post '/identification', identifiant: '4', date_naiss: '1970-01-01'
-    get '/eleve'
-    assert_match /Musique/, last_response.body
-    assert_match /facultatif/, last_response.body
-  end
+  #   post '/identification', identifiant: '4', date_naiss: '1970-01-01'
+  #   get '/eleve'
+  #   assert_match /Musique/, last_response.body
+  #   assert_match /facultatif/, last_response.body
+  # end
 
   def test_un_agent_supprime_option
     post '/agent', identifiant: 'pierre', mot_de_passe: 'demaulmont'

--- a/views/1_eleve.erb
+++ b/views/1_eleve.erb
@@ -115,35 +115,20 @@
 
     <span style="display:block; height: 20px;"></span>
 
-    <% if options_obligatoires.present? %>
-      <h3 class="separation">Enseignement obligatoire</h3>
+<!--     Options
+ -->
+      <h3 class="separation">Options d'enseignement</h3>
 
-      <% options_obligatoires.each do |groupe, options| %>
-        <% nom_options = options.map { |o| o.nom } %>
-        <% radio = [{
-          label: groupe,
-          name: groupe,
-          type: "radio",
-          options: nom_options,
-          checked: nom_options.select {|nom| eleve.option.map {|o| o.nom}.include? nom}.first
+      <% eleve.option.sort_by(&:groupe).each do |opt| %>
+        <% info = [{
+          type: "info",
+          label: opt.groupe,
+          valeur: opt.nom,
           }]
         %>
-        <%= construire radio %>
+        <%= construire info %>
       <% end %>
       <span style="display:block; height: 20px;"></span>
-    <% end %>
-
-    <% if options_facultatives.present? %>
-      <h3 class="separation">Enseignement facultatif</h3>
-      <p><em>Le choix d'un enseignement facultatif engage votre enfant à le suivre jusqu'à la fin de sa scolarité au collège.</em></p>
-      <% options_facultatives.each do |option| %>
-        <% option_cochee = eleve.option.include? option %>
-        <%= erb :'partials/champ_check', locals: {
-          desc: option.nom,
-          name: option.nom,
-          condition: option_cochee }%>
-      <% end %>
-    <% end %>
 
     <%= erb :'partials/nouveau_precedent_suivant', :locals => { :precedent => "accueil"} %>
   </form>

--- a/views/partials/champ.erb
+++ b/views/partials/champ.erb
@@ -1,6 +1,6 @@
 <%	case type
 	when "text", "date"
-=begin 
+=begin
 
 VARIABLES
 
@@ -37,7 +37,7 @@ disabled		pour	disabled
 <span style="display:block; height: <%= hauteur %>px;"></span>
 
 <%	when "dropdown"
-=begin 
+=begin
 
 VARIABLES
 
@@ -72,7 +72,7 @@ selected	"CM2"
 </div>
 
 <%	when "radio"
-=begin 
+=begin
 
 VARIABLES
 
@@ -100,7 +100,26 @@ checked			anglais: pour cocher Anglais par défaut
 				> <%= option %>
 				<%= required if defined? required %>
 			</label>
-    	<% end %> 		
+		<% end %>
+	</div>
+</div>
+
+<%	when "info"
+=begin
+
+VARIABLES
+
+name
+label 			"LV1"
+valeur			"Anglais"
+
+=end
+%>
+
+<div class="form-group row">
+	<label class="col-sm-4 col-form-label"><%= label %></label>
+	<div class="col-sm-6">
+		<%= valeur %>
 	</div>
 </div>
 


### PR DESCRIPTION
Temporairement et pour s'adapter à la situation de Beaumarchais, qui a déjà transmis un message aux parents d'une 6è bilangue les invitant sur le site à titre de test:
- cache les options facultatives (Latin/Grec)
- affiche les options langues vivantes sans possibilité d'édition

…en attendant qu'on réflechisse sur la façon de traiter les possibilités pour les familles d'exprimer des choix seulement lorsque c'est pertinent