### PR TITLE
Simplifie le message de fin de parcours

### DIFF
--- a/to_do.txt
+++ b/to_do.txt
@@ -37,6 +37,7 @@ Mineurs:
 [ ] améliorer l'affichage de la pagination liste_des_eleves
 [ ] 2ème ou 3ème prénoms, préciser "optionnel"
 [ ] apostrophe française ’ (en cours)
+[ ] La valeur de 'demarche' codée en dur
 
 Améliorer les tests ou l'exploitabilité:
 [ ] Tester l'import des options de rang > 1

--- a/views/7_confirmation.erb
+++ b/views/7_confirmation.erb
@@ -1,4 +1,4 @@
-<% demarche = "inscription" %>
+<% demarche = "reinscription" %>
 <% @section = 6 %>
 
 <%= erb :'partials/navigation' %>
@@ -11,18 +11,13 @@
     <h2 class="separation">Réinscription validée</h2>
   <% end %>
 
-  <p>Nous avons envoyé un mail de confirmation aux adresses suivantes :</p>
+  <p>Vous recevrez prochainement un courriel de confirmation aux adresses suivantes :</p>
 
   <ul>
     <% dossier_eleve.resp_legal.each do |resp_legal| %>
       <%= "<li>#{resp_legal.email}</li>" if resp_legal.email.present? %>
     <% end %>
   </ul>
-
-  <% if demarche == "inscription" %>
-    <p>Une permanence est assurée si vous souhaitez venir nous rencontrer :
-    <%= dossier_eleve.etablissement.message_permanence %></p>
-  <% end %>
 
   <p class='mb-5'>A bientôt au <%= dossier_eleve.etablissement.nom %> !</p>
 


### PR DESCRIPTION
N'affiche plus le message sur la permanence en fin de parcours: remarque de notre contact à Beaumarchais ("Pourquoi on précise à la fin du parcours qu'on peut ne pas utiliser l'outil? Et nous n'allons pas organiser de permanence.")

Modifie l'intitulé "Inscription" en "Réinscription". Attention, la valeur de la démarche est codée en dur.

Reformule le message prévenant de l'envoi d'un mail, afin de ne pas créer des attentes trop fortes (aller tout de suite vérifier sa boite aux lettres).