### PR TITLE
Respecte la touche Cmd/Ctrl pour ouvrir un élève dans un onglet

### DIFF
--- a/views/agent/liste_des_eleves.erb
+++ b/views/agent/liste_des_eleves.erb
@@ -79,8 +79,10 @@
     })
   })
   jQuery(document).ready(function($) {
-    $(".clickable-row").click(function() {
-        window.location = $(this).data("href");
+    $(".clickable-row").click(function(event) {
+      var href = $(this).data("href")
+      if (event.metaKey) { window.open(href, '_blank') }
+      else { window.location.replace(href) }
     });
     $('#table_liste_des_eleves').DataTable({
       "order": [[ 0, "desc" ]],


### PR DESCRIPTION
Ceci afin de pouvoir afficher une classe entière puis ouvrir plusieurs élèves dans de nouveaux onglets sans perdre ses options de tri ou de filtrage. Besoin temporaire pour l'édition des PDF élèves d'un établissement pilote, mais qui pourrait être adopté de façon permanente.