### PR TITLE
Précise l'encoding dans le template des mails

### DIFF
--- a/views/mailers/agent_mailer/contacter_une_famille.text.erb
+++ b/views/mailers/agent_mailer/contacter_une_famille.text.erb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 Bonjour,
 
 Nous vous avons invité·e à procéder à la réinscription de votre enfant <%= @eleve.prenom %> <%= @eleve.nom %> à son établissement: <%= @eleve.dossier_eleve.etablissement.nom %>. Nous vous remercions de vous être connecté·e et d'avoir débuté la démarche.

--- a/views/mailers/agent_mailer/envoyer_mail_confirmation.text.erb
+++ b/views/mailers/agent_mailer/envoyer_mail_confirmation.text.erb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 Bonjour,
 
 Nous vous avons invité·e à procéder à la réinscription de votre enfant <%= @eleve.prenom %> <%= @eleve.nom %> à son établissement: <%= @eleve.dossier_eleve.etablissement.nom %>.

--- a/views/mailers/agent_mailer/mail_validation_inscription.text.erb
+++ b/views/mailers/agent_mailer/mail_validation_inscription.text.erb
@@ -1,3 +1,5 @@
+# encoding: utf-8
+
 Bonjour,
 
 Nous vous avons invité·e à procéder à la réinscription de votre enfant <%= @eleve.prenom %> <%= @eleve.nom %> à son établissement: <%= @eleve.dossier_eleve.etablissement.nom %>.


### PR DESCRIPTION
Pour tenter de corriger l'erreur remontée par Sentry :

`Error ActionView::Template::Error /agent/contacter_une_famille` 


Your template was not saved as valid US-ASCII. Please either specify US-ASCII as the encoding for your template in your text editor, or mark the template with its encoding by inserting the following as the first line of the template:

`# encoding: <name of correct encoding>.`


> Nous vous avons invité·e à procéder à la réinscription de votre enfant <%= @eleve.prenom %> <%= @eleve.nom %> à son établissement: <%= @eleve.dossier_eleve.etablissement.nom %>. Nous vous remercions de vous être connecté·e et d'avoir débuté la démarche.

L'encoding semble être utf-8 plutôt que US-ASCII :

```
$ grep -lr procéder *|xargs file -i 
agent_mailer/contacter_une_famille.text.erb:       charset=utf-8
agent_mailer/envoyer_mail_confirmation.text.erb:   charset=utf-8
agent_mailer/mail_validation_inscription.text.erb: charset=utf-8
```

Ca fait passer les tests mais je ne sais pas comment tester l'envoie de mail lui-même.