### PR TITLE
Evite le blocage occasionnel quand demi-pensionnaire est coché

### DIFF
--- a/dossiersco_web.rb
+++ b/dossiersco_web.rb
@@ -185,11 +185,7 @@ post '/administration' do
 	dossier_eleve.renseignements_medicaux = params['renseignements_medicaux']
   dossier_eleve.check_paiement_cantine = params['check_paiement_cantine']
 	dossier_eleve.save!
-  if dossier_eleve.demi_pensionnaire && !dossier_eleve.check_paiement_cantine
-    erb :'4_administration', locals: {dossier_eleve: dossier_eleve, message_cantine: "Vous devez accepter les conditions ci-dessus"}
-  else
-	  sauve_et_redirect dossier_eleve, 'pieces_a_joindre'
-  end
+	sauve_et_redirect dossier_eleve, 'pieces_a_joindre'
 end
 
 get '/piece/:dossier_eleve/:code_piece/:s3_key' do

--- a/to_do.txt
+++ b/to_do.txt
@@ -22,7 +22,7 @@ Mineurs:
 [ ] 2ème ou 3ème prénoms, préciser "optionnel"
 [ ] apostrophe française ’ (en cours)
 [ ] La valeur de 'demarche' codée en dur
-[ ] Bug sur la case d'engagement demi-pension
+[X] Bug sur la case d'engagement demi-pension
 [ ] permettre à un user admin (pierre) de basculer d'un établissement à l'autre
 [ ] permettre la déconnexion de l'application pour plus de sécurité
 

--- a/views/4_administration.erb
+++ b/views/4_administration.erb
@@ -28,10 +28,7 @@
 
 			<div id="dp" style="display: none;">
 
-				<%= erb :'partials/champ_check', :locals => { :desc => "Je m'engage à régler les frais de demi-pension en
-					respectant les délais impartis inhérents au bon fonctionnement du service.", name: 'check_paiement_cantine',
-					condition: dossier_eleve.check_paiement_cantine}%>
-					<p style="color: red"><%= message_cantine if defined? message_cantine %></p>
+				<p>Je m'engage à régler les frais de demi-pension en respectant les délais impartis inhérents au bon fonctionnement du service.</p>
 			</div>
 		</div>
 

--- a/views/4_administration.erb
+++ b/views/4_administration.erb
@@ -28,7 +28,7 @@
 
 			<div id="dp" style="display: none;">
 
-				<p>Je m'engage à régler les frais de demi-pension en respectant les délais impartis inhérents au bon fonctionnement du service.</p>
+				<p class="text-danger">En validant cette étape, je m'engage à régler les frais de demi-pension dans les délais impartis.</p>
 			</div>
 		</div>
 


### PR DESCRIPTION
Constaté en test utilisateur et par Lucien et moi. Se produit à la fois sur chrome et firefox.