### PR TITLE
Ajoute un test et correctif pour un bug sur administration 

### DIFF
--- a/helpers/init.rb
+++ b/helpers/init.rb
@@ -160,7 +160,7 @@ def cree_dossier_eleve eleve, etablissement, etat
     lien_de_parente: 'Mère', prenom: 'Gertrude', nom: 'Martin',
     adresse: '42 rue de la fin', code_postal: '75020', ville: 'Paris',
     tel_principal: '0123456789', tel_secondaire: '0987654321', email: 'test@test.com',
-    situation_emploi: 'Employé', profession: 'concierge', enfants_a_charge: 3,
+    situation_emploi: 'Employé', profession: 'concierge', enfants_a_charge: nil,
     enfants_a_charge_secondaire: 2, communique_info_parents_eleves: true,
     priorite: 1)
   RespLegal.create!(dossier_eleve_id: dossier_eleve.id,

--- a/models/dossier_eleve.rb
+++ b/models/dossier_eleve.rb
@@ -6,6 +6,7 @@ class DossierEleve < ActiveRecord::Base
   has_many :piece_jointe
 
   def allocataire
-    self.resp_legal.first.enfants_a_charge > 1
+    enfants = self.resp_legal.first.enfants_a_charge || 0
+    enfants > 1
   end
 end

--- a/tests/test_eleve_form.rb
+++ b/tests/test_eleve_form.rb
@@ -613,6 +613,7 @@ class EleveFormTest < Test::Unit::TestCase
 
   def test_une_famille_remplit_letape_administration
     post '/identification', identifiant: '2', date_naiss: '1915-12-19'
+    get '/administration'
     post '/administration', demi_pensionnaire: true, autorise_sortie: true,
       renseignements_medicaux: true, autorise_photo_de_classe: false
     get '/administration'


### PR DESCRIPTION
Lorsque enfants à charge n'est pas renseigné, le test DossierEleve::allocataire lève une exception.