### PR TITLE
Affiche l'enveloppe sur la liste des eleves uniquement si les resp legaux ont un mail

### DIFF
--- a/dossiersco_agent.rb
+++ b/dossiersco_agent.rb
@@ -99,7 +99,9 @@ end
 
 get '/agent/eleve/:identifiant' do
   eleve = Eleve.find_by(identifiant: params[:identifiant])
-  erb :'agent/eleve', locals: {agent: agent, eleve: eleve }, layout: :layout_agent
+  emails_presents = false
+  eleve.dossier_eleve.resp_legal.each { |r| (emails_presents = true) if r.email.present?}
+  erb :'agent/eleve', locals: {emails_presents: emails_presents, agent: agent, eleve: eleve }, layout: :layout_agent
 end
 
 post '/agent/change_etat_fichier' do

--- a/tests/test_eleve_form.rb
+++ b/tests/test_eleve_form.rb
@@ -701,6 +701,29 @@ class EleveFormTest < Test::Unit::TestCase
     assert_equal "✓", doc.css("tbody > tr:nth-child(1) > td:nth-child(6)").text.strip
   end
 
+  def test_affiche_lenvoi_de_message_uniquement_si_un_des_resp_legal_a_un_mail
+    e = Eleve.create!(identifiant: 'XXX', date_naiss: '1970-01-01')
+    dossier_eleve = DossierEleve.create!(eleve_id: e.id, etablissement_id: Etablissement.first.id)
+    resp_legal = RespLegal.create(email: 'test@test.com', dossier_eleve_id: dossier_eleve.id)
+
+    post '/agent', identifiant: 'pierre', mot_de_passe: 'demaulmont'
+    get "/agent/eleve/XXX"
+
+    assert last_response.body.include? "Ce formulaire envoie un message à la famille de l'élève."
+  end
+
+  def test_affiche_lenveloppe_uniquement_si_un_des_resp_legal_a_un_mail
+    e = Eleve.create!(identifiant: 'XXX', date_naiss: '1970-01-01')
+    dossier_eleve = DossierEleve.create!(eleve_id: e.id, etablissement_id: Etablissement.first.id)
+    resp_legal = RespLegal.create(email: 'test@test.com', dossier_eleve_id: dossier_eleve.id)
+
+    post '/agent', identifiant: 'pierre', mot_de_passe: 'demaulmont'
+    get '/agent/liste_des_eleves'
+
+    doc = Nokogiri::HTML(last_response.body)
+    assert_equal "far fa-envelope", doc.css("tbody > tr:nth-child(1) > td").last.children[1].children[0].attributes['class'].value
+  end
+
   def test_changement_statut_famille_connecte
     post '/identification', identifiant: '2', date_naiss: '1915-12-19'
     dossier_eleve = Eleve.find_by(identifiant: '2').dossier_eleve

--- a/to_do.txt
+++ b/to_do.txt
@@ -5,6 +5,7 @@ Evolutions fonctionnelles importantes:
 [ ] Tableau de bord avec les statistiques par classe sur /stats
 
 Observation de l'usage:
+[ ] Afficher le logo PDF dans la partie pièce jointe, l'image actuelle porte a confusion
 [ ] Emailing (Mailjet? autre?) parents (en complément des actions "recherche de feedback" parents)
 
 Important mais moins urgent:
@@ -12,10 +13,10 @@ Important mais moins urgent:
 [ ] Notifier la famille des options pédagogiques affectées (Tillion)
 
 Mineurs:
+[ ] individualiser le bloc de la demi-pension par collège
 [ ] Permettre aux familles d'adresser un message à l'établissement ?
 [ ] Améliorer le comparatif ancienne / nouvelle adresse
 [ ] Afficher email et téléphone des responsables légaux dans la vue agent (domicile)
-[ ] Ne pas afficher l'icône enveloppe à droite de la liste des élèves si pas de mail
 
 Améliorer les tests ou l'exploitabilité:
 [ ] Séparer les tests en plusieurs fichiers

--- a/views/agent/eleve.erb
+++ b/views/agent/eleve.erb
@@ -170,17 +170,26 @@ scolarite_ant = [
 <div class="col-12 col-md-8">
     <h2 class="separation mt-3">Envoyer un message</h2>
 
-    <div class='card'>
-      <div class='card-body'>
-        <p>Ce formulaire envoie un message à la famille de l'élève. Précisez par exemple si les pièces justificatives ne sont pas conformes, et ce que la famille doit transmettre.</p>
+    <% if emails_presents %>
+      <div class='card'>
+        <div class='card-body'>
+          <p>Ce formulaire envoie un message à la famille de l'élève. Précisez par exemple si les pièces justificatives ne sont pas conformes, et ce que la famille doit transmettre.</p>
+        </div>
       </div>
-    </div>
 
-    <form action="/agent/contacter_une_famille" method="POST" class="text-center">
-      <input type="hidden" name="identifiant" value="<%= eleve.identifiant %>" />
-      <textarea name='message' class="form-control" rows="6"></textarea>
-      <input id='envoyer-commentaire' value='Envoyer' type='submit' class='btn btn-outline-primary mb-5 mt-1'/>
-    </form>
+      <form action="/agent/contacter_une_famille" method="POST" class="text-center">
+        <input type="hidden" name="identifiant" value="<%= eleve.identifiant %>" />
+        <textarea name='message' class="form-control" rows="6"></textarea>
+        <input id='envoyer-commentaire' value='Envoyer' type='submit' class='btn btn-outline-primary mb-5 mt-1'/>
+      </form>
+    <% else %>
+      <div class='card'>
+        <div class='card-body'>
+          <p>Cette famille ne possède pas d'adresse email</p>
+        </div>
+      </div>
+
+    <% end %>
 
     <h2 class="separation">Identité de l'élève</h2>
 

--- a/views/agent/liste_des_eleves.erb
+++ b/views/agent/liste_des_eleves.erb
@@ -61,9 +61,12 @@
               <% end %>
             </td>
           <% end %>
-
-            <td><a href="/agent/eleve/<%= dossier_eleve.eleve.identifiant %>"><i class="far fa-envelope"></i></a></td>
-
+            <td>
+              <% if dossier_eleve.resp_legal.first.email.present? ||
+                ( dossier_eleve.resp_legal[1].present? && dossier_eleve.resp_legal[1].email.present?) %>
+                <a href="/agent/eleve/<%= dossier_eleve.eleve.identifiant %>"><i class="far fa-envelope"></i></a>
+              <% end %>
+            </td>
         </tr>
       <% end %>
     </tbody>


### PR DESCRIPTION
je n'ai pas encore fait de tests sur l'affichage de l'enveloppe, j'ai essayé plusieurs moyens mais aucun n'était concluant