### PR TITLE
Utilise sqlite3:memory pour accélérer les tests

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -2,7 +2,7 @@ FROM ruby AS base
 WORKDIR /app
 COPY Gemfile .
 COPY Gemfile.lock .
-RUN bundle install
+RUN apt-get install libsqlite3-dev && bundle install
 
 FROM base AS service
 WORKDIR /app

--- a/Gemfile
+++ b/Gemfile
@@ -19,4 +19,5 @@ gem 'actionmailer'
 group :test do
   gem 'nokogiri'
   gem 'rack-test'
+  gem 'sqlite3'
 end

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -138,6 +138,7 @@ GEM
       sinatra (>= 1.0)
     spreadsheet (1.1.7)
       ruby-ole (>= 1.0)
+    sqlite3 (1.3.13)
     thread_safe (0.3.6)
     tilt (2.0.8)
     ttfunk (1.5.1)
@@ -169,6 +170,7 @@ DEPENDENCIES
   shotgun
   sinatra
   sinatra-activerecord
+  sqlite3
 
 BUNDLED WITH
    1.16.2

--- a/config/database.yml
+++ b/config/database.yml
@@ -11,7 +11,8 @@ development:
   <<: *default
 
 test:
-  <<: *default
+  adapter: sqlite3
+  database: ":memory:"
 
 staging:
   <<: *default

--- a/tests/test_eleve_form.rb
+++ b/tests/test_eleve_form.rb
@@ -19,6 +19,8 @@ class EleveFormTest < Test::Unit::TestCase
   end
 
   def setup
+    ActiveRecord::Schema.verbose = false
+    require_relative "../db/schema.rb"
     init
     ActionMailer::Base.delivery_method = :test
     ActionMailer::Base.deliveries = []


### PR DESCRIPTION
Reste à faire:
- [x] Configurer CircleCI pour utiliser PostgresQL: plus lent mais plus sécurisant, en cas de différences de dialecte SQL entre SQLite et PostgresQL

(…en fait c'est le cas par défaut.)