### PR TITLE
Optimise le temps de chargement de la liste des élèves

### DIFF
--- a/dossiersco_agent.rb
+++ b/dossiersco_agent.rb
@@ -46,12 +46,20 @@ post '/agent' do
 end
 
 get '/agent/liste_des_eleves' do
-  dossier_eleves = agent.etablissement.dossier_eleve.sort_by { |dossier| dossier.eleve.identifiant}
+  lignes_eleves = DossierEleve
+    .joins(:eleve,:resp_legal)
+    .select('*')
+    .select('dossier_eleves.id as dossier_id')
+    .where(resp_legals:{priorite:1}, etablissement: agent.etablissement)
   message_info = session[:message_info]
   session.delete :message_info
   erb :'agent/liste_des_eleves',
       layout: :layout_agent,
-      locals: {agent: agent, dossier_eleves: dossier_eleves, message_info: message_info}
+      locals: {
+          agent: agent,
+          lignes_eleves: lignes_eleves,
+          message_info: message_info,
+          pieces_attendues: agent.etablissement.piece_attendue}
 end
 
 get '/agent/tableau_de_bord' do

--- a/dossiersco_agent.rb
+++ b/dossiersco_agent.rb
@@ -54,12 +54,10 @@ get '/agent/liste_des_eleves' do
     .select('resp_legals.changement_adresse').select('resp_legals.email')
     .order('eleves.classe_ant DESC, dossier_eleves.etat, eleves.identifiant')
     .where(resp_legals:{priorite:1}, etablissement: agent.etablissement)
-    .all
   pieces_jointes = PieceJointe
     .joins(:dossier_eleve,:piece_attendue)
     .select('dossier_eleves.id as dossier_id').select('piece_jointes.*')
     .where(piece_attendues:{etablissement_id: agent.etablissement.id})
-    .all
     .group_by(&:dossier_eleve_id)
   message_info = session[:message_info]
   session.delete :message_info

--- a/dossiersco_agent.rb
+++ b/dossiersco_agent.rb
@@ -56,9 +56,9 @@ get '/agent/liste_des_eleves' do
     .where(resp_legals:{priorite:1}, etablissement: agent.etablissement)
     .all
   pieces_jointes = PieceJointe
-    .left_outer_joins(:dossier_eleve,:piece_attendue)
+    .joins(:dossier_eleve,:piece_attendue)
+    .select('dossier_eleves.id as dossier_id').select('piece_jointes.*')
     .where(piece_attendues:{etablissement_id: agent.etablissement.id})
-    .select('dossier_eleves.id as dossier_id').select('*')
     .all
     .group_by(&:dossier_eleve_id)
   message_info = session[:message_info]

--- a/dossiersco_agent.rb
+++ b/dossiersco_agent.rb
@@ -52,7 +52,7 @@ get '/agent/liste_des_eleves' do
     .select('dossier_eleves.*')
     .select('eleves.*')
     .select('resp_legals.changement_adresse').select('resp_legals.email')
-    .order('eleves.classe_ant DESC, dossier_eleves.etat')
+    .order('eleves.classe_ant DESC, dossier_eleves.etat, eleves.identifiant')
     .where(resp_legals:{priorite:1}, etablissement: agent.etablissement)
     .all
   pieces_jointes = PieceJointe

--- a/tests/test_eleve_form.rb
+++ b/tests/test_eleve_form.rb
@@ -677,6 +677,16 @@ class EleveFormTest < Test::Unit::TestCase
   #   assert doc.css("select[name='classes'] option").collect(&:text).include? "4EME ULIS"
   # end
 
+  def test_liste_des_eleves
+    eleve = Eleve.find_by(identifiant: 2)
+
+    post '/agent', identifiant: 'pierre', mot_de_passe: 'demaulmont'
+    get '/agent/liste_des_eleves'
+    doc = Nokogiri::HTML(last_response.body)
+    assert_equal "Edith", doc.css("##{eleve.dossier_eleve.id} td:nth-child(2)").text.strip
+    assert_equal "Piaf", doc.css("##{eleve.dossier_eleve.id} td:nth-child(3)").text.strip
+  end
+
   def test_affiche_changement_adresse_liste_eleves
     # Si on a un changement d'adresse
     eleve = Eleve.find_by(identifiant: 2)

--- a/tests/test_eleve_form.rb
+++ b/tests/test_eleve_form.rb
@@ -687,6 +687,22 @@ class EleveFormTest < Test::Unit::TestCase
     assert_equal "Piaf", doc.css("##{eleve.dossier_eleve.id} td:nth-child(3)").text.strip
   end
 
+  def test_etat_piece_jointe_liste_des_eleves
+    dossier_eleve = Eleve.find_by(identifiant: 2).dossier_eleve
+    piece_attendue = PieceAttendue.find_by(code: 'assurance_scolaire',
+      etablissement_id: dossier_eleve.etablissement.id)
+    piece_jointe = PieceJointe.create(clef: 'assurance_scannee.pdf', dossier_eleve_id: dossier_eleve.id,
+      piece_attendue_id: piece_attendue.id)
+
+    post '/agent', identifiant: 'pierre', mot_de_passe: 'demaulmont'
+    post '/agent/change_etat_fichier', id: piece_jointe.id, etat: 'valide'
+
+    get '/agent/liste_des_eleves'
+    doc = Nokogiri::HTML(last_response.body)
+    assert doc.css("##{dossier_eleve.id} td:nth-child(7) a i.fa-file-image").present?
+    assert_equal "color: #00cf00", doc.css("##{dossier_eleve.id} td:nth-child(7) i.fa-check-circle").attr("style").text
+  end
+
   def test_affiche_changement_adresse_liste_eleves
     # Si on a un changement d'adresse
     eleve = Eleve.find_by(identifiant: 2)

--- a/views/agent/liste_des_eleves.erb
+++ b/views/agent/liste_des_eleves.erb
@@ -27,7 +27,7 @@
       <th>Etat</th>
       <th><i class="fas fa-truck"></i></th>
       <th><i class="fas fa-utensils"></i></th>
-      <% agent.etablissement.piece_attendue.each do |piece| %>
+      <% pieces_attendues.each do |piece| %>
         <th><%= piece.nom %></th>
       <% end %>
       <th><i class="far fa-envelope"></i></th>
@@ -48,7 +48,8 @@
           </td>
 
           <% pieces_attendues.each do |piece| %>
-            <% piece_jointe = PieceJointe.find_by(dossier_eleve_id: ligne_eleve.dossier_id, piece_attendue_id: piece.id) %>
+            <% piece_jointe = pieces_jointes[ligne_eleve.dossier_id] &&
+                              pieces_jointes[ligne_eleve.dossier_id].find {|x| x.piece_attendue_id == piece.id} %>
             <td class="text-center" data-piece-id="<%= piece_jointe.id if piece_jointe.present? %>">
               <% if piece_jointe.present? %>
                 <a class="lien-piece-jointe" data-toggle="modal" data-target="#modal-pieces-jointes"

--- a/views/agent/liste_des_eleves.erb
+++ b/views/agent/liste_des_eleves.erb
@@ -13,7 +13,7 @@
   </div>
 
   <div>
-    <%= agent.etablissement.nom %> : <span id="total_dossiers" class="badge badge-danger"><%= dossier_eleves.count %></span> dossiers.
+    <%= agent.etablissement.nom %> : <span id="total_dossiers" class="badge badge-danger"><%= lignes_eleves.count('*') %></span> dossiers.
   </div>
 
   <span style="display:block; height: 20px;"></span>
@@ -33,26 +33,26 @@
       <th><i class="far fa-envelope"></i></th>
     </tr></thead>
     <tbody>
-      <% dossier_eleves.each do |dossier_eleve| %>
-        <% cliquable = "class='clickable-row' data-href='/agent/eleve/#{dossier_eleve.eleve.identifiant}'" %>
-        <tr id="<%= dossier_eleve.id %>" style='cursor:pointer'>
-          <td <%= cliquable %> ><%= dossier_eleve.eleve.classe_ant %></td>
-          <td <%= cliquable %> ><%= dossier_eleve.eleve.prenom %></td>
-          <td <%= cliquable %> ><%= dossier_eleve.eleve.nom %></td>
-          <td <%= cliquable %> ><%= dossier_eleve.etat %></td>
+      <% lignes_eleves.each do |ligne_eleve| %>
+        <% cliquable = "class='clickable-row' data-href='/agent/eleve/#{ligne_eleve.identifiant}'" %>
+        <tr id="<%= ligne_eleve.id %>" style='cursor:pointer'>
+          <td <%= cliquable %> ><%= ligne_eleve.classe_ant %></td>
+          <td <%= cliquable %> ><%= ligne_eleve.prenom %></td>
+          <td <%= cliquable %> ><%= ligne_eleve.nom %></td>
+          <td <%= cliquable %> ><%= ligne_eleve.etat %></td>
           <td <%= cliquable %> >
-            <%= dossier_eleve.resp_legal.first.changement_adresse ? "✓" : "" %>
+            <%= ligne_eleve.changement_adresse ? "✓" : "" %>
           </td>
           <td <%= cliquable %> >
-            <%= dossier_eleve.demi_pensionnaire ? "✓" : "" %>
+            <%= ligne_eleve.demi_pensionnaire ? "✓" : "" %>
           </td>
 
-          <% agent.etablissement.piece_attendue.each do |piece| %>
-            <% piece_jointe = PieceJointe.find_by(dossier_eleve_id: dossier_eleve.id, piece_attendue_id: piece.id) %>
+          <% pieces_attendues.each do |piece| %>
+            <% piece_jointe = PieceJointe.find_by(dossier_eleve_id: ligne_eleve.dossier_id, piece_attendue_id: piece.id) %>
             <td class="text-center" data-piece-id="<%= piece_jointe.id if piece_jointe.present? %>">
               <% if piece_jointe.present? %>
                 <a class="lien-piece-jointe" data-toggle="modal" data-target="#modal-pieces-jointes"
-                    data-url="<%= FichierUploader::route_lecture(dossier_eleve.eleve.identifiant, piece.code) + "/" + piece_jointe.clef %>"
+                    data-url="<%= FichierUploader::route_lecture(ligne_eleve.identifiant, piece.code) + "/" + piece_jointe.clef %>"
                     data-ext="<%= piece_jointe.ext %>">
                   <i class="fas fa-file-image"></i>
                 </a>
@@ -62,9 +62,8 @@
             </td>
           <% end %>
             <td>
-              <% if dossier_eleve.resp_legal.first.email.present? ||
-                ( dossier_eleve.resp_legal[1].present? && dossier_eleve.resp_legal[1].email.present?) %>
-                <a href="/agent/eleve/<%= dossier_eleve.eleve.identifiant %>"><i class="far fa-envelope"></i></a>
+              <% if ligne_eleve.email.present? %>
+                <a href="/agent/eleve/<%= ligne_eleve.identifiant %>"><i class="far fa-envelope"></i></a>
               <% end %>
             </td>
         </tr>


### PR DESCRIPTION
Dans l'environnement de développement, on passe de 3.9s à 2.3s pour le chargement de la liste des élèves; le temps effectif de rendu de la page est de 150ms, le rendu d'une page vide prend 2.25s. Le résultat réel est à vérifier sur staging mais cette PR devrait rendre le chargement de la page presque instantané.

La version optimisée est plus susceptible de régressions, puisqu'on interroge directement des jointures SQL plutôt que des objets du modèle dont les attributs (et leur unicité) sont garantis. Ainsi `etat` de la pièce jointe peut être ambigu avec `etat` du dossier élève. Des tests unitaires complémentaires s'imposent donc sur la liste des élèves, cette PR en ajoute 2.

Un changement de comportement par rapport à la version antérieure: on effectue la jointure seulement sur le responsable légal de priorité 1, donc on n'affichera un picto enveloppe que si ce responsable a déclaré son adresse mail, et non plus l'un des deux.