### PR TITLE
Ne met plus l'établissement en copie des mails émis

### DIFF
--- a/mailers/agent_mailer.rb
+++ b/mailers/agent_mailer.rb
@@ -3,7 +3,7 @@ class AgentMailer < ActionMailer::Base
 
     def emails
         @eleve.dossier_eleve.resp_legal.map{ |resp_legal| resp_legal.email } +
-            ['contact@dossiersco.beta.gouv.fr', @eleve.dossier_eleve.etablissement.email]
+            ['contact@dossiersco.beta.gouv.fr']
     end
 
     def contacter_une_famille(eleve, message)

--- a/tests/test_eleve_form.rb
+++ b/tests/test_eleve_form.rb
@@ -837,7 +837,6 @@ class EleveFormTest < Test::Unit::TestCase
     assert_equal 'contact@dossiersco.beta.gouv.fr', mail['from'].to_s
     assert mail['to'].addresses.collect(&:to_s).include? 'test@test.com'
     assert mail['to'].addresses.collect(&:to_s).include? 'test2@test.com'
-    assert mail['to'].addresses.collect(&:to_s).include? 'etablissement@email.com'
     assert mail['to'].addresses.collect(&:to_s).include? 'contact@dossiersco.beta.gouv.fr'
     assert mail['reply_to'].addresses.collect(&:to_s).include? 'etablissement@email.com'
     assert mail['reply_to'].addresses.collect(&:to_s).include? 'contact@dossiersco.beta.gouv.fr'


### PR DESCRIPTION
Demande d'un l'établissement confronté à un volume de mail inhabituel; l'affichage de l'historique des messages individuels rend moins intéressant d'adresser les mails également à l'établissement.